### PR TITLE
allow tailing semi-colon in short syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Typography is syntax plugin. Currently it covers all typographic aspects of CSS.
 It gives ability to adjust settings for text look, but does not influence subtle stuff like text baseline or vertical alignment.
 
 
-Syntax
-------
+## Syntax
 
 `<typo parameters>`beautiful looking test`</typo>` where parameters are semicolon separated `name:value;` 
 
@@ -23,6 +22,15 @@ Syntax
 |letter spacing  | `<typo ls:20px;>`Text`</typo>` | values below zero allowed |
 |spacing between word  | `<typo ws:20px;>`Text`</typo>` | values below zero allowed |
 
+## Shorter syntax
+
+The Typography plugin provides additional short (or single property) syntax those are compatible with [fontcolor](https://www.dokuwiki.org/plugin:fontcolor), [fontfamily](https://www.dokuwiki.org/plugin:fontfamily) and [fontsize2](https://www.dokuwiki.org/plugin:fontsize2) plugins. If you have enabled these three plugins, the short syntax are treated by relevant plugins instead of this plugin. These short syntax are available through toolbar icons: ![fontcolor icon](https://raw.githubusercontent.com/ssahara/dw-plugin-typography/master/images/fontcolor/picker.png) ![fontfamily icon](https://raw.githubusercontent.com/ssahara/dw-plugin-typography/master/images/fontfamily/picker.png) ![font-size icon](https://raw.githubusercontent.com/ssahara/dw-plugin-typography/master/images/fontsize/picker.png).
+
+```
+  <fc Turquoise>Specific color text</fc>        = <typo fc:Turquoise;>Specific color text</typo>
+  <ff 'Comic Sans MS'>Different font used</ff>  = <typo ff:'Comic Sans MS';>Different font used</typo>
+  <fs 200%>Large size text</fs>                 = <typo fs:200%;>Large size text</typo>
+```
 
 ----
 Licensed under the GNU Public License (GPL) version 2

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Extended version from original [Typography plugin](http://treecode.pl/typography
 
 Sometimes there is need for nice looking slogan, quotation or article paragraph. For full control you need full control over font displaing as CSS can give. Typography plugin extends DokuWiki markup by typesetting abilities. It brings all font related directives from CSS as wiki syntax.
 
-Typography is syntax plugin. Currently it covers all typographic aspects of CSS. 
-
 It gives ability to adjust settings for text look, but does not influence subtle stuff like text baseline or vertical alignment.
 
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base  typography
 name  Typography plugin
 author Paweł Piekarski
 email  <qentinson@gmail.com>
-date   2016-10-02
+date   2017-01-08
 desc   Empower dokuwiki with html typographic capabilities.
 url    https://www.dokuwiki.org/plugin:typography

--- a/syntax/fontcolor.php
+++ b/syntax/fontcolor.php
@@ -13,7 +13,7 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontcolor extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<fc\b(?: .+?)?>(?=.+?</fc>)';
+    protected $entry_pattern = '<fc\b.*?>(?=.*?</fc>)';
     protected $exit_pattern  = '</fc>';
 
     // Connect pattern to lexer

--- a/syntax/fontfamily.php
+++ b/syntax/fontfamily.php
@@ -13,7 +13,7 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontfamily extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<ff\b(?: .+?)?>(?=.+?</ff>)';
+    protected $entry_pattern = '<ff\b.*?>(?=.*?</ff>)';
     protected $exit_pattern  = '</ff>';
 
     // Connect pattern to lexer

--- a/syntax/fontsize.php
+++ b/syntax/fontsize.php
@@ -13,7 +13,7 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontsize extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<fs\b(?: .+?)?>(?=.+?</fs>)';
+    protected $entry_pattern = '<fs\b.*?>(?=.*?</fs>)';
     protected $exit_pattern  = '</fs>';
 
     // Connect pattern to lexer


### PR DESCRIPTION
The usage of shorter syntax is now compatible with relevant other plugins: fontcolor, fontfamily, fontsize2.
```
<fc red>red color</fc> 
<fc red;>red color</fc>
```