### PR TITLE
css parser as separated helper component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Some specific **short name** are also available as markup tag; `<ff>` (font fami
 |  `fs`  | font-size         | font size of text (large or small) |
 |  `fw`  | font-weight       | weight of a font (thick or thin characters in text) |
 |  `fv`  | font-variant      | display text in a small-caps font |
-|  `ff`  | font-family       | font family for text, must be single quoted if a font name contains white-space |
+|  `ff`  | font-family       | font family for text, must be single quoted if a font name contains white-space or non-ASCII characters |
 |  `lh`  | line-height       | space between the lines |
 |  `ls`  | letter-spacing    | an extra space between characters  (in px, em, etc) |
 |  `ws`  | word-spacing      | an additional space between words (in px, em, etc) |

--- a/helper/parser.php
+++ b/helper/parser.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * DokuWiki plugin Typography; helper component
+ *
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author Satoshi Sahara <sahara.satoshi@gmail.com>
+ */
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+class helper_plugin_typography_parser extends DokuWiki_Plugin {
+
+    protected $props, $cond;
+
+    function __construct() {
+        // allowable parameters and relevant CSS properties
+        $this->props = array(
+            'ff' => 'font-family',
+            'fc' => 'color',
+            'bg' => 'background-color',
+            'fs' => 'font-size',
+            'fw' => 'font-weight',
+            'fv' => 'font-variant',
+            'lh' => 'line-height',
+            'ls' => 'letter-spacing',
+            'ws' => 'word-spacing',
+            'va' => 'vertical-align',
+            'sp' => 'white-space',
+        );
+
+        // allowable property pattern for parameters
+        $this->conds = array(
+            'ff' => '/^((\'[^,]+?\'|[^ ,]+?) *,? *)+$/',
+            'fc' => '/(^\#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$)|'
+                   .'(^rgb\((\d{1,3}%?,){2}\d{1,3}%?\)$)|'
+                   .'(^[a-zA-Z]+$)/',
+            'bg' => '/(^\#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$)|'
+                   .'(^rgb\((\d{1,3}%?,){2}\d{1,3}%?\)$)|'
+                   .'(^rgba\((\d{1,3}%?,){3}[\d.]+\)$)|'
+                   .'(^[a-zA-Z]+$)/',
+            'font-size' =>
+                 '/^(?:\d+(?:\.\d+)?(?:px|em|ex|pt|%)'
+                .'|(?:x{1,2}-)?small|medium|(?:x{1,2}-)?large|smaller|larger)$/',
+            'font-weight' =>
+                 '/^(?:\d00|normal|bold|bolder|lighter)$/',
+            'font-variant' =>
+                 '/^(?:normal|small-?caps)$/',
+            'line-height' =>
+                 '/^\d+(?:\.\d+)?(?:px|em|ex|pt|%)?$/',
+            'letter-spacing' =>
+                 '/^-?\d+(?:\.\d+)?(?:px|em|ex|pt|%)$/',
+            'word-spacing' =>
+                 '/^-?\d+(?:\.\d+)?(?:px|em|ex|pt|%)$/',
+            'vertical-align' =>
+                 '/^-?\d+(?:\.\d+)?(?:px|em|ex|pt|%)$|'
+                .'^(?:baseline|sub|super|top|text-top|middle|bottom|text-bottom|inherit)$/',
+            'white-space' =>
+                 '/^(?:normal|nowrap|pre|pre-line|pre-wrap)$/',
+        );
+    }
+
+    /**
+     * validation of CSS property short name
+     *
+     * @param   string $name  short name of CSS property
+     * @return  bool  true if defined
+     */
+    function is_short_property($name) {
+        return isset($this->props[$name]);
+    }
+
+    /**
+     * parse style attribute of an element
+     *
+     * @param   string $style  style attribute of an element
+     * @return  array  an associative array containing CSS property-value pairs
+     */
+    function parse_inlineCSS($style) {
+        $css = array();
+        if (empty($style)) return $css;
+
+        $declarations = explode(';', $style);
+
+        foreach ($declarations as $declaration) {
+            $property = array_map('trim', explode(':', $declaration, 2));
+            if (!isset($property[1])) continue;
+
+            // check CSS property name
+            if (isset($this->props[$property[0]])) {
+                $name = $this->props[$property[0]];
+            } elseif (in_array($property[0], $this->props)) {
+                $name = $property[0];
+            } else {
+                continue;
+            }
+
+            // check CSS property value
+            if (isset($this->conds[$name])) {
+                if (preg_match($this->conds[$name], $property[1], $matches)) {
+                    $value = $property[1];
+                } else {
+                    continue;
+                }
+                if (($name == 'font-variant') && ($value == 'smallcaps')) {
+                    $value = 'small-caps';
+                }
+            } else {
+                $value = htmlspecialchars($property[1], ENT_COMPAT, 'UTF-8');
+            }
+            //$css[$name] = $value;
+            $css += array($name => $value);
+        }
+        return $css;
+    }
+
+    /**
+     * build inline CSS for style attribute of an element
+     *
+     * @param   array $declarations  CSS property-value pairs
+     * @return  string  inline CSS for style attribute
+     */
+    function build_inlineCSS($declarations) {
+        $css = array();
+        foreach ($declarations as $name => $value) {
+            $css[] = $name.':'.$value.';';
+        }
+        return implode(' ', $css);
+    }
+
+}

--- a/syntax/smallcaps.php
+++ b/syntax/smallcaps.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * DokuWiki Plugin Typography; Syntax typography smallcaps
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
+ *
+ */
+
+require_once(dirname(__FILE__).'/base.php');
+
+class syntax_plugin_typography_smallcaps extends syntax_plugin_typography_base {
+
+    protected $entry_pattern = '<smallcaps\b.*?>(?=.*?</smallcaps>)';
+    protected $exit_pattern  = '</smallcaps>';
+
+    //protected $styler = null;
+
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
+        switch($state) {
+            case DOKU_LEXER_ENTER:
+                // load prameter parser utility
+                if (is_null($this->styler)) {
+                    $this->styler = $this->loadHelper('typography_parser');
+                }
+
+                // get inline CSS parameter
+                $params = 'fv:small-caps;'.strtolower(ltrim(substr($match, 10, -1)));
+
+                // get css property:value pairs as an associative array
+                $css = $this->styler->parse_inlineCSS($params);
+
+                return array($state, $css);
+
+            case DOKU_LEXER_UNMATCHED:
+                $handler->_addCall('cdata', array($match), $pos);
+                return false;
+
+            case DOKU_LEXER_EXIT:
+                return array($state, '');
+        }
+        return array();
+    }
+
+}


### PR DESCRIPTION
css parser utility should be reused in any syntax sub-components of this plugin. 
 