### PR TITLE
better Webfont support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Some specific **short name** are also available as markup tag; `<ff>` (font fami
 |  `va`  | vertical-align    | sets the vertical alignment |
 |  -     | text-transform  | controls capitalization of text (capitalize, uppercase or lowercase) |
 |  -     | text-shadow      | adds shadow to text |
+|  `wf`  | (web-font)   | specify a web font class which prefixed "wf-" (not css property) |
 
 Sometimes, inline styles are necessary when you are building a page by hand. You should however avoid them whenever possible for "semantic markup", better maintainability, and reusability. The [wrap plugin](https://www.dokuwiki.org/plugin:wrap) will provide most powerful and flexible method for specifying a class attribute.
 

--- a/action.php
+++ b/action.php
@@ -13,9 +13,7 @@ class action_plugin_typography extends DokuWiki_Action_Plugin {
     /**
      * register the event handlers
      */
-    public function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'deleteObsoletedSingleClass');
-
+    function register(Doku_Event_Handler $controller) {
         if (plugin_isdisabled('fontcolor')) {
             $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'fontColorToolbar', array());
         }
@@ -27,20 +25,12 @@ class action_plugin_typography extends DokuWiki_Action_Plugin {
         }
     }
 
-    /**
-     * Delete syntax.php which is obsoleted since multi-components syntax structure
-     */
-    public function deleteObsoletedSingleClass(Doku_Event $event) {
-        $legacyFile = dirname(__FILE__).'/syntax.php';
-        if (file_exists($legacyFile)) { unlink($legacyFile); }
-    }
-
 
     /**
      * Adds FontColor toolbar button
      * @see https://www.dokuwiki.org/plugin:fontcolor
      */
-    public function fontColorToolbar(Doku_Event $event, $param) {
+    function fontColorToolbar(Doku_Event $event, $param) {
         $title_note = '';
         $colors = array(
                 'Yellow' => '#ffff00',
@@ -96,7 +86,7 @@ class action_plugin_typography extends DokuWiki_Action_Plugin {
      * Adds FontFamily toolbar button
      * @see https://www.dokuwiki.org/plugin:fontcfamily
      */
-    public function fontFamilyToolbar(Doku_Event $event, $param) {
+    function fontFamilyToolbar(Doku_Event $event, $param) {
         $options = array(
             'serif'       => 'serif',
             'sans-serif'  => 'sans-serif',
@@ -126,7 +116,7 @@ class action_plugin_typography extends DokuWiki_Action_Plugin {
      * Adds FontSize toolbar button
      * @see https://www.dokuwiki.org/plugin:fontsize2
      */
-    public function fontSizeToolbar(Doku_Event $event, $param) {
+    function fontSizeToolbar(Doku_Event $event, $param) {
         $options = array(
             'xxs'     => 'xx-small',
             'xs'      =>  'x-small',

--- a/deleted.files
+++ b/deleted.files
@@ -1,0 +1,8 @@
+# deleted.files : Typography plugin for DokuWiki
+#
+# This file contains a list of files that were present in previous
+# plugin releases but were removed later. 
+# An up-to-date plugin should not have any of the files installed.
+
+# Since 2014-07-29
+syntax.php

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -12,8 +12,8 @@ class helper_plugin_typography_odt extends DokuWiki_Plugin {
 
     protected $closing_stack = NULL; // used in odt_render()
 
-    public function render(Doku_Renderer $renderer, $indata) {
-        list($state, $data) = $indata;
+    public function render(Doku_Renderer $renderer, $data) {
+        list($state, $tag_data) = $data;
 
         if (is_null($this->closing_stack)) {
             $this->closing_stack = new SplStack(); //require PHP 5 >= 5.3.0
@@ -23,7 +23,7 @@ class helper_plugin_typography_odt extends DokuWiki_Plugin {
             case DOKU_LEXER_ENTER:
                 // build inline css
                 $css = array();
-                foreach ($data['declarations'] as $name => $value) {
+                foreach ($tag_data['declarations'] as $name => $value) {
                     $css[] = $name.':'.$value.';';
                 }
                 $style = implode(' ', $css);

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -23,6 +23,7 @@ class helper_plugin_typography_odt extends DokuWiki_Plugin {
             case DOKU_LEXER_ENTER:
                 // build css rule-set
                 $css = array();
+                unset($data['class']);
                 foreach ($data as $name => $value) {
                     $css[] = $name.':'.$value.';';
                 }

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -21,10 +21,9 @@ class helper_plugin_typography_odt extends DokuWiki_Plugin {
 
         switch ($state) {
             case DOKU_LEXER_ENTER:
-                // build css rule-set
+                // build inline css
                 $css = array();
-                unset($data['class']);
-                foreach ($data as $name => $value) {
+                foreach ($data['declarations'] as $name => $value) {
                     $css[] = $name.':'.$value.';';
                 }
                 $style = implode(' ', $css);

--- a/helper/parser.php
+++ b/helper/parser.php
@@ -15,7 +15,7 @@ class helper_plugin_typography_parser extends DokuWiki_Plugin {
     function __construct() {
         // allowable parameters and relevant CSS properties
         $this->props = array(
-            'wf' => 'wf',           // exceptional class="wf_webfont"
+            'wf' => 'wf',           // exceptional class="wf-webfont"
             'ff' => 'font-family',
             'fc' => 'color',
             'bg' => 'background-color',
@@ -33,6 +33,7 @@ class helper_plugin_typography_parser extends DokuWiki_Plugin {
 
         // allowable property pattern for parameters
         $this->conds = array(
+            'wf' => '/^[a-zA-Z_-]+$/',
             'ff' => '/^((\'[^,]+?\'|[^ ,]+?) *,? *)+$/',
             'fc' => '/(^\#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$)|'
                    .'(^rgb\((\d{1,3}%?,){2}\d{1,3}%?\)$)|'

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -4,6 +4,6 @@ author Paweł Piekarski
 email  <qentinson@gmail.com>
 author Satoshi Sahara
 email  <sahara.satoshi@gmail.com>
-date   2017-06-18
+date   2017-07-17
 desc   Enable typesetting capabilities with CSS font properties such as font face, size, weight, and color of text
 url    https://www.dokuwiki.org/plugin:typography

--- a/syntax/base.php
+++ b/syntax/base.php
@@ -103,10 +103,8 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
                 if (is_null($this->styler)) {
                     $this->styler = $this->loadHelper('typography_parser');
                 }
-                // build inline CSS
-                $style = $this->styler->build_inlineCSS($data);
-                $attr = $style ? ' style="'.$style.'"' : '';
-                $renderer->doc .= '<span'.$attr.'>';
+                // build attributes (style and class)
+                $renderer->doc .= '<span'.$this->styler->build_attributes($data).'>';
                 break;
 
             case DOKU_LEXER_EXIT:

--- a/syntax/base.php
+++ b/syntax/base.php
@@ -83,22 +83,22 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
     /*
      * Create output
      */
-    function render($format, Doku_Renderer $renderer, $indata) {
-        if (empty($indata)) return false;
+    function render($format, Doku_Renderer $renderer, $data) {
+        if (empty($data)) return false;
         switch ($format) {
             case 'xhtml':
-                return $this->render_xhtml($renderer, $indata);
+                return $this->render_xhtml($renderer, $data);
             case 'odt':
                 // ODT export;
                 $odt = $this->loadHelper('typography_odt');
-                return $odt->render($renderer, $indata);
+                return $odt->render($renderer, $data);
             default:
                 return false;
         }
     }
 
-    protected function render_xhtml(Doku_Renderer $renderer, $indata) {
-        list($state, $data) = $indata;
+    protected function render_xhtml(Doku_Renderer $renderer, $data) {
+        list($state, $tag_data) = $data;
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 // load prameter parser utility
@@ -106,7 +106,7 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
                     $this->styler = $this->loadHelper('typography_parser');
                 }
                 // build attributes (style and class)
-                $renderer->doc .= '<span'.$this->styler->build_attributes($data).'>';
+                $renderer->doc .= '<span'.$this->styler->build_attributes($tag_data).'>';
                 break;
 
             case DOKU_LEXER_EXIT:

--- a/syntax/base.php
+++ b/syntax/base.php
@@ -12,23 +12,25 @@ if(!defined('DOKU_INC')) die();
 
 class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
 
-    protected $entry_pattern = '<typo\b.*?>(?=.*?</typo>)';
-    protected $exit_pattern  = '</typo>';
+    protected $pattern = array(
+        1 => '<typo\b.*?>(?=.*?</typo>)',
+        4 => '</typo>',
+    );
 
     protected $mode;
     protected $styler = null;
 
-    public function __construct() {
+    function __construct() {
         $this->mode = substr(get_class($this), 7); // drop 'syntax_' from class name
     }
 
-    public function getType() { return 'formatting'; }
-    public function getSort() { return 67; } // = Doku_Parser_Mode_formatting:strong -3
-    public function getAllowedTypes() {
+    function getType() { return 'formatting'; }
+    function getSort() { return 67; } // = Doku_Parser_Mode_formatting:strong -3
+    function getAllowedTypes() {
         return array('formatting', 'substition', 'disabled');
     }
     // plugin accepts its own entry syntax
-    public function accepts($mode) {
+    function accepts($mode) {
         if ($mode == $this->mode) return true;
         return parent::accepts($mode);
     }
@@ -36,17 +38,17 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
     /**
      * Connect pattern to lexer
      */
-    public function connectTo($mode) {
-        $this->Lexer->addEntryPattern($this->entry_pattern, $mode, $this->mode);
+    function connectTo($mode) {
+        $this->Lexer->addEntryPattern($this->pattern[1], $mode, $this->mode);
     }
-    public function postConnect() {
-        $this->Lexer->addExitPattern($this->exit_pattern, $this->mode);
+    function postConnect() {
+        $this->Lexer->addExitPattern($this->pattern[4], $this->mode);
     }
 
     /*
      * Handle the match
      */
-    public function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch($state) {
             case DOKU_LEXER_ENTER:
                 // load prameter parser utility
@@ -54,8 +56,8 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
                     $this->styler = $this->loadHelper('typography_parser');
                 }
 
-                // identify markup keyword
-                $markup = substr($this->exit_pattern, 2, -1);
+                // identify markup keyword of this syntax class
+                $markup = substr($this->pattern[4], 2, -1);
 
                 // get inline CSS parameter
                 $params = strtolower(ltrim(substr($match, strlen($markup)+1, -1)));
@@ -64,9 +66,9 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
                 }
 
                 // get css property:value pairs as an associative array
-                $css = $this->styler->parse_inlineCSS($params);
+                $tag_data = $this->styler->parse_inlineCSS($params);
 
-                return array($state, $css);
+                return array($state, $tag_data);
 
             case DOKU_LEXER_UNMATCHED:
                 $handler->_addCall('cdata', array($match), $pos);
@@ -81,7 +83,7 @@ class syntax_plugin_typography_base extends DokuWiki_Syntax_Plugin {
     /*
      * Create output
      */
-    public function render($format, Doku_Renderer $renderer, $indata) {
+    function render($format, Doku_Renderer $renderer, $indata) {
         if (empty($indata)) return false;
         switch ($format) {
             case 'xhtml':

--- a/syntax/fontcolor.php
+++ b/syntax/fontcolor.php
@@ -13,13 +13,20 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontcolor extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<fc\b.*?>(?=.*?</fc>)';
-    protected $exit_pattern  = '</fc>';
+    protected $pattern = array(
+        1 => '<fc\b.*?>(?=.*?</fc>)',
+        4 => '</fc>',
+    );
 
     // Connect pattern to lexer
-    public function connectTo($mode) {
+    function connectTo($mode) {
         if (plugin_isdisabled('fontcolor')) {
-            $this->Lexer->addEntryPattern($this->entry_pattern, $mode, $this->mode);
+            $this->Lexer->addEntryPattern($this->pattern[1], $mode, $this->mode);
+        }
+    }
+    function postConnect() {
+        if (plugin_isdisabled('fontcolor')) {
+            $this->Lexer->addExitPattern($this->pattern[4], $this->mode);
         }
     }
 

--- a/syntax/fontfamily.php
+++ b/syntax/fontfamily.php
@@ -13,13 +13,20 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontfamily extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<ff\b.*?>(?=.*?</ff>)';
-    protected $exit_pattern  = '</ff>';
+    protected $pattern = array(
+        1 => '<ff\b.*?>(?=.*?</ff>)',
+        4 => '</ff>',
+    );
 
     // Connect pattern to lexer
-    public function connectTo($mode) {
+    function connectTo($mode) {
         if (plugin_isdisabled('fontfamily')) {
-            $this->Lexer->addEntryPattern($this->entry_pattern, $mode, $this->mode);
+            $this->Lexer->addEntryPattern($this->pattern[1], $mode, $this->mode);
+        }
+    }
+    function postConnect() {
+        if (plugin_isdisabled('fontfamily')) {
+            $this->Lexer->addExitPattern($this->pattern[4], $this->mode);
         }
     }
 

--- a/syntax/fontsize.php
+++ b/syntax/fontsize.php
@@ -13,13 +13,20 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontsize extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<fs\b.*?>(?=.*?</fs>)';
-    protected $exit_pattern  = '</fs>';
+    protected $pattern = array(
+        1 => '<fs\b.*?>(?=.*?</fs>)',
+        4 => '</fs>',
+    );
 
     // Connect pattern to lexer
-    public function connectTo($mode) {
+    function connectTo($mode) {
         if (plugin_isdisabled('fontsize2')) {
-            $this->Lexer->addEntryPattern($this->entry_pattern, $mode, $this->mode);
+            $this->Lexer->addEntryPattern($this->pattern[1], $mode, $this->mode);
+        }
+    }
+    function postConnect() {
+        if (plugin_isdisabled('fontsize2')) {
+            $this->Lexer->addExitPattern($this->pattern[4], $this->mode);
         }
     }
 

--- a/syntax/fontweight.php
+++ b/syntax/fontweight.php
@@ -11,7 +11,9 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_fontweight extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<fw\b.*?>(?=.*?</fw>)';
-    protected $exit_pattern  = '</fw>';
+    protected $pattern = array(
+        1 => '<fw\b.*?>(?=.*?</fw>)',
+        4 => '</fw>',
+    );
 
 }

--- a/syntax/smallcaps.php
+++ b/syntax/smallcaps.php
@@ -11,12 +11,17 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_smallcaps extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<smallcaps\b.*?>(?=.*?</smallcaps>)';
-    protected $exit_pattern  = '</smallcaps>';
+    protected $pattern = array(
+        1 => '<smallcaps\b.*?>(?=.*?</smallcaps>)',
+        4 => '</smallcaps>',
+    );
 
     //protected $styler = null;
 
-    public function handle($match, $state, $pos, Doku_Handler $handler) {
+    /*
+     * Handle the match
+     */
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch($state) {
             case DOKU_LEXER_ENTER:
                 // load prameter parser utility
@@ -28,9 +33,9 @@ class syntax_plugin_typography_smallcaps extends syntax_plugin_typography_base {
                 $params = 'fv:small-caps;'.strtolower(ltrim(substr($match, 10, -1)));
 
                 // get css property:value pairs as an associative array
-                $css = $this->styler->parse_inlineCSS($params);
+                $tag_data = $this->styler->parse_inlineCSS($params);
 
-                return array($state, $css);
+                return array($state, $tag_data);
 
             case DOKU_LEXER_UNMATCHED:
                 $handler->_addCall('cdata', array($match), $pos);

--- a/syntax/webfont.php
+++ b/syntax/webfont.php
@@ -11,7 +11,9 @@ require_once(dirname(__FILE__).'/base.php');
 
 class syntax_plugin_typography_webfont extends syntax_plugin_typography_base {
 
-    protected $entry_pattern = '<wf\b.*?>(?=.*?</wf>)';
-    protected $exit_pattern  = '</wf>';
+    protected $pattern = array(
+        1 => '<wf\b.*?>(?=.*?</wf>)',
+        4 => '</wf>',
+    );
 
 }

--- a/syntax/webfont.php
+++ b/syntax/webfont.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * DokuWiki Plugin Typography; Syntax typography webfont
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
+ *
+ */
+
+require_once(dirname(__FILE__).'/base.php');
+
+class syntax_plugin_typography_webfont extends syntax_plugin_typography_base {
+
+    protected $entry_pattern = '<wf\b.*?>(?=.*?</wf>)';
+    protected $exit_pattern  = '</wf>';
+
+}


### PR DESCRIPTION
New syntax parameter `<wf: webfontname>` (web font), while relevant css class `.wf-webfontname {font-family: webfontname;}` may be defined in conf/meta.html file

Typography plugin renders `<span>` tag with **class** attribute, as well as **style** attribute. 